### PR TITLE
2993 - Update packages on stacks-dotnet-packages-testing

### DIFF
--- a/src/Amido.Stacks.Testing.Tests/Amido.Stacks.Testing.Tests.csproj
+++ b/src/Amido.Stacks.Testing.Tests/Amido.Stacks.Testing.Tests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Amido.Stacks.Testing/Amido.Stacks.Testing.csproj
+++ b/src/Amido.Stacks.Testing/Amido.Stacks.Testing.csproj
@@ -11,13 +11,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.10" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.16" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.16" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.16" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.16" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.16" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.16" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.16" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
2993 - Update packages on stacks-dotnet-packages-testing

📲 What

Updating packages to Microsoft June 2021 release for .net core 3.1

🤔 Why

To prevent vulnerabilities

🛠 How

Updating packages

🕵️ How to test

Run tests again

✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
